### PR TITLE
BrokenPipeError is resolved

### DIFF
--- a/python/alstread.py
+++ b/python/alstread.py
@@ -144,9 +144,11 @@ if __name__ == '__main__':
                 fp_l6.buffer.write(rcv.l6)
                 fp_l6.flush()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(rcv.msg_color.fg('yellow') + "User break - terminated" + rcv.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/gale6read.py
+++ b/python/gale6read.py
@@ -60,9 +60,11 @@ if __name__ == '__main__':
                 continue
             gale6.decode_has_message()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(gale6.msg_color.fg('yellow') + "User break - terminated" + gale6.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/novread.py
+++ b/python/novread.py
@@ -235,10 +235,12 @@ if __name__ == '__main__':
                 print(msg, file=fp_disp)
                 fp_disp.flush()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(rcv.msg_color.fg('yellow') + "User break - terminated" + \
-            rcv.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + \
+            libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/psdrread.py
+++ b/python/psdrread.py
@@ -128,10 +128,12 @@ if __name__ == '__main__':
                 if gale6.ready_decoding_has(rcv.satid, rcv.e6b):
                     gale6.decode_has_message()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(rcv.msg_color.fg('yellow') + "User break - terminated" + \
-            rcv.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + \
+            libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/qzsl1sread.py
+++ b/python/qzsl1sread.py
@@ -373,10 +373,12 @@ if __name__ == '__main__':
         else:               # read from stdin
             read_from_stdin(qzsl1s, fp_disp)
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(rcv.msg_color.fg('yellow') + "User break - terminated" + \
-            rcv.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + \
+            libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/qzsl6read.py
+++ b/python/qzsl6read.py
@@ -52,10 +52,12 @@ if __name__ == '__main__':
         while qzsl6.read_l6_msg():
             qzsl6.show_l6_msg()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(qzsl6.msg_color.fg('yellow') + "User break - terminated" + \
-            qzsl6.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + \
+            libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/rtcmread.py
+++ b/python/rtcmread.py
@@ -37,10 +37,12 @@ if __name__ == '__main__':
         while rtcm.read():
             rtcm.decode_rtcm_msg()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(rtcm.msg_color.fg('yellow') + "User break - terminated" + \
-            rtcm.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + \
+            libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/septread.py
+++ b/python/septread.py
@@ -225,10 +225,12 @@ if __name__ == '__main__':
                 print(msg, file=fp_disp)
                 fp_disp.flush()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(rcv.msg_color.fg('yellow') + "User break - terminated" + \
-            rcv.msg_color.fg(), file=sys.stderr)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + \
+            libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF

--- a/python/ubxread.py
+++ b/python/ubxread.py
@@ -253,10 +253,12 @@ if __name__ == '__main__':
                     fp_raw.buffer.write(raw)
                     fp_raw.flush()
     except (BrokenPipeError, IOError):
-        sys.exit()
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
     except KeyboardInterrupt:
-        print(rcv.msg_color.fg('yellow') + "User break - terminated" + \
-            rcv.msg_color.fg(), file=fp_disp)
+        print(libcolor.Color().fg('yellow') + "User break - terminated" + \
+            libcolor.Color().fg(), file=sys.stderr)
         sys.exit()
 
 # EOF


### PR DESCRIPTION
As mentioned in [issue](https://github.com/yoronneko/qzsl6tool/issues/15), BrokenPipeError is encountered when we use pipe and terminate it. This is because the code still produces output even when the pipe is broken.
This can be resolved by redirecting output to a null device.