### PR TITLE
alstread.py: PRN range is set to 193-211 or 0

### DIFF
--- a/docs/en/alstread.md
+++ b/docs/en/alstread.md
@@ -15,7 +15,7 @@ options:
   -c, --color        apply ANSI color escape sequences even for non-terminal.
   -l, --l6           send QZS L6 messages to stdout (it also turns off Allystar and u-blox messages).
   -m, --message      show Allystar messages to stderr.
-  -p PRN, --prn PRN  satellite PRN to be specified.
+  -p PRN, --prn PRN  satellite PRN to be specified (0, 193-211).
 ```
 
 When the `-c` option is given, it forces the status display to appear in color. By default, if the output destination is a terminal, the status display appears in color. If the output destination is something else, color display is not used.

--- a/docs/ja/alstread.md
+++ b/docs/ja/alstread.md
@@ -15,7 +15,7 @@ options:
   -c, --color        apply ANSI color escape sequences even for non-terminal.
   -l, --l6           send QZS L6 messages to stdout (it also turns off Allystar and u-blox messages).
   -m, --message      show Allystar messages to stderr.
-  -p PRN, --prn PRN  satellite PRN to be specified.
+  -p PRN, --prn PRN  satellite PRN to be specified (0, 193-211).
 ```
 
 ``-c``オプションを与えると、強制的にカラーにて状態表示します。デフォルトでは、出力先がターミナルであれば、状態表示はカラーにて表示されます。出力先がそれ以外であれば、カラー表示されません。

--- a/python/alstread.py
+++ b/python/alstread.py
@@ -117,15 +117,15 @@ if __name__ == '__main__':
         help='show Allystar messages to stderr.')
     parser.add_argument(
         '-p', '--prn', type=int, default=0,
-        help='satellite PRN to be specified.')
+        help='satellite PRN to be specified (0, 193-211).')
     args = parser.parse_args()
     fp_disp, fp_raw = sys.stdout, None
     if args.l6:  # QZS L6 raw message output to stdout
         fp_disp, fp_raw = None, sys.stdout
     if args.message:  # Allystar message to stderr
         fp_disp = sys.stderr
-    if args.prn not in {0, 193, 194, 195, 196, 199}:
-        libtrace.warn("PRN to be specified is either 193-196, or 199, all PRNs are selected.")
+    if (args.prn < 193 or 211 < args.prn) and args.prn != 0:
+        libtrace.warn("QZS L6 PRN is in range of 193-211 or 0")
         args.prn = 0
     trace = libtrace.Trace(fp_disp, 0, args.color)
     rcv = AllystarReceiver(trace)


### PR DESCRIPTION
QZSS is plan to transmit new MADOCA-PPP signals and the PRN range is going to be 193-211. PRN 0 means choosing PRN that has the highest C/No among all PRNs.