### PR TITLE
Bug fix: RTCM Galileo navigation message

### DIFF
--- a/python/libeph.py
+++ b/python/libeph.py
@@ -282,16 +282,16 @@ class Eph:
             msg += f'E{r.svid:02d} WN={r.wn} IODnav={r.iodn}'
             if   mtype == 'F/NAV':
                 if r.osh:
-                    msg += self.trace.msg(0, f' unhealthy OS ({r.osh.uint})', fg='red')
+                    msg += self.trace.msg(0, f' unhealthy OS ({r.osh})', fg='red')
                 if r.osv:
                     msg += self.trace.msg(0, ' invalid OS', fg='red')
             elif mtype == 'I/NAV':
                 if r.e5h:
-                    msg += self.trace.msg(0, f' unhealthy E5b ({r.e5h.uint})', fg='red')
+                    msg += self.trace.msg(0, f' unhealthy E5b ({r.e5h})', fg='red')
                 if r.e5v:
                     msg += self.trace.msg(0, ' invalid E5b', fg='red')
                 if r.e1h:
-                    msg += self.trace.msg(0, f' unhealthy E1b ({r.e1h.uint})', fg='red')
+                    msg += self.trace.msg(0, f' unhealthy E1b ({r.e1h})', fg='red')
                 if r.e1v:
                     msg += self.trace.msg(0, ' invalid E1b', fg='red')
             else:

--- a/readme-en.md
+++ b/readme-en.md
@@ -1,4 +1,4 @@
-# QZS L6 Tool: quasi-zenith satellite L6-band tool, ver.0.1.2
+# QZS L6 Tool: quasi-zenith satellite L6-band tool, ver.0.1.3
 
 ![QZS L6 Tool](docs/img/qzsl6tool.png)
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# QZS L6 Tool: quasi-zenith satellite L6-band tool, ver.0.1.2
+# QZS L6 Tool: quasi-zenith satellite L6-band tool, ver.0.1.3
 
 ![QZS L6 Tool](docs/img/qzsl6tool.png)
 

--- a/release_note.md
+++ b/release_note.md
@@ -1,5 +1,8 @@
 # Release Note on QZS L6 Tool
 
+## ver.0.1.3 (2024-09-07)
+- Bug fix: RTCM Galileo navigation message
+
 ## ver.0.1.2 (2024-08-30)
 - Usage of bitstring's read: e.g. df.read('u10') -> df.read(10).u
 - Merge libobs.py to rtcmread.py


### PR DESCRIPTION
Bug fix of type error of decoding Galileo navigation message:
  File ".../libeph.py", line 290, in decode_ephemerides
    msg += self.trace.msg(0, f' unhealthy E5b ({r.e5h.uint})', fg='red')
AttributeError: 'int' object has no attribute 'uint'
