### PR TITLE
[codex] Add PyPI packaging metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ $RECYCLE.BIN/
 # =========================
 
 __pycache__/
+build/
+dist/
+*.egg-info/
 config/pet/snippet.toml
 config/OpenMV/
 gnupg/random_seed
@@ -61,4 +64,3 @@ vnc/*.log
 vnc/*.pid
 
 # EOF
-

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
 --------------------------------------------------------------------------------
 QZS L6 Tool: quasi-zenith satellite L6-band tool
 
-Released under The 2-Cluse BSD License
+Released under The 2-Clause BSD License
 https://opensource.org/licenses/BSD-2-Clause
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,10 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Topic :: Scientific/Engineering",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,97 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qzsl6tool"
+version = "0.1.7"
+description = "Command-line tools for reading and converting GNSS messages, including QZSS L6, RTCM, Galileo HAS, and BeiDou PPP-B2b data."
+readme = "readme-en.md"
+requires-python = ">=3.8"
+license = "BSD-2-Clause"
+license-files = ["license.txt"]
+authors = [
+    { name = "Satoshi Takahashi", email = "git@s-taka.org" },
+]
+dependencies = [
+    "bitstring",
+    "galois",
+    "numpy",
+]
+keywords = [
+    "GNSS",
+    "QZSS",
+    "RTCM",
+    "CLAS",
+    "MADOCA",
+    "Galileo HAS",
+    "BeiDou",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "Natural Language :: English",
+    "Natural Language :: Japanese",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+]
+
+[project.urls]
+Homepage = "https://github.com/yoronneko/qzsl6tool"
+Repository = "https://github.com/yoronneko/qzsl6tool"
+Documentation = "https://github.com/yoronneko/qzsl6tool/tree/main/docs"
+"Release Notes" = "https://github.com/yoronneko/qzsl6tool/blob/main/release_note.md"
+"Bug Tracker" = "https://github.com/yoronneko/qzsl6tool/issues"
+
+[tool.setuptools]
+py-modules = [
+    "alstread",
+    "bdsb2read",
+    "gale6read",
+    "galinavread",
+    "l6rtcm4050",
+    "libecef",
+    "libgnsstime",
+    "libnav",
+    "libqznma",
+    "libqzsl6tool",
+    "libssr",
+    "libtrace",
+    "novread",
+    "psdrread",
+    "qzsl1sread",
+    "qzsl6read",
+    "rtcmread",
+    "septread",
+    "ubxread",
+]
+script-files = [
+    "python/alstread.py",
+    "python/bdsb2read.py",
+    "python/ecef2llh.py",
+    "python/gale6read.py",
+    "python/galinavread.py",
+    "python/gps2utc.py",
+    "python/l6rtcm4050.py",
+    "python/llh2ecef.py",
+    "python/novread.py",
+    "python/psdrread.py",
+    "python/qzsl1sread.py",
+    "python/qzsl6read.py",
+    "python/rtcmread.py",
+    "python/septread.py",
+    "python/ubxread.py",
+    "python/utc2gps.py",
+]
+
+[tool.setuptools.package-dir]
+"" = "python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qzsl6tool"
 version = "0.1.7"
 description = "Command-line tools for reading and converting GNSS messages, including QZSS L6, RTCM, Galileo HAS, and BeiDou PPP-B2b data."
 readme = "readme-en.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "BSD-2-Clause"
 license-files = ["license.txt"]
 authors = [

--- a/readme-en.md
+++ b/readme-en.md
@@ -16,9 +16,18 @@
 ## Operating Environment
 
 - It is intended for use on the command line of Linux or macOS.
-- Python 3.8 or later is required. The ``bitstring`` module and the ``galois`` module are required.  
-``pip3 install bitstring galois``
+- Python 3.8 or later is required.
 - With a Docker environment such as Docker Desktop, this tool can also be used on Windows, macOS, Linux, and Raspberry Pi OS inside a Linux container. The Docker image includes the Python runtime, ``nc``, and ``str2str`` from RTKLIB 2.4.3 b34.
+
+Installing from PyPI
+
+```bash
+python3 -m pip install qzsl6tool
+qzsl6read.py < sample/2022001A.l6
+str2str -in ntrip://ntrip.rnav.info.hiroshima-cu.ac.jp:80/OEM7 2>/dev/null | rtcmread.py
+```
+
+The PyPI package installs the required Python dependencies such as ``bitstring``, ``galois``, and ``numpy``. External command-line tools such as ``nc`` and RTKLIB ``str2str`` should be installed separately when needed.
 
 Building a Docker image
 

--- a/readme-en.md
+++ b/readme-en.md
@@ -16,7 +16,7 @@
 ## Operating Environment
 
 - It is intended for use on the command line of Linux or macOS.
-- Python 3.8 or later is required.
+- Python 3.10 or later is required.
 - With a Docker environment such as Docker Desktop, this tool can also be used on Windows, macOS, Linux, and Raspberry Pi OS inside a Linux container. The Docker image includes the Python runtime, ``nc``, and ``str2str`` from RTKLIB 2.4.3 b34.
 
 Installing from PyPI

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,18 @@
 ## 動作環境
 
 - LinuxやmacOSのコマンドラインで利用することを想定しています。
-- Python 3.7以降が必要です。``bitstring``モジュールと``galois``モジュールが必要です。  
-``pip3 install bitstring galois``
+- Python 3.8以降が必要です。
 - Docker DesktopなどのDocker環境では、Windows上、macOS上、Linux上、Raspberry Pi OS上でもLinuxコンテナ内で本ツールを利用できます。DockerイメージにはPython実行環境、``nc``、RTKLIB 2.4.3 b34の``str2str``が含まれます。
+
+PyPIからのインストール
+
+```bash
+python3 -m pip install qzsl6tool
+qzsl6read.py < sample/2022001A.l6
+str2str -in ntrip://ntrip.rnav.info.hiroshima-cu.ac.jp:80/OEM7 2>/dev/null | rtcmread.py
+```
+
+PyPIパッケージでは、``bitstring``、``galois``、``numpy``などのPython依存パッケージも一緒にインストールされます。``nc``やRTKLIBの``str2str``などの外部コマンドは、必要に応じて別途インストールしてください。
 
 Dockerイメージのビルド
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@
 ## 動作環境
 
 - LinuxやmacOSのコマンドラインで利用することを想定しています。
-- Python 3.8以降が必要です。
+- Python 3.10以降が必要です。
 - Docker DesktopなどのDocker環境では、Windows上、macOS上、Linux上、Raspberry Pi OS上でもLinuxコンテナ内で本ツールを利用できます。DockerイメージにはPython実行環境、``nc``、RTKLIB 2.4.3 b34の``str2str``が含まれます。
 
 PyPIからのインストール


### PR DESCRIPTION
## Summary

- Add `pyproject.toml` metadata for publishing `qzsl6tool` to PyPI.
- Document `pip install qzsl6tool` usage in the Japanese and English READMEs.
- Ignore local packaging build outputs and fix a BSD license typo.

## Validation

- `python -m twine check dist/*`
- Installed `qzsl6tool==0.1.7` from TestPyPI and production PyPI in fresh virtual environments.
- Ran `qzsl6read.py --help` and processed `sample/2022001A.l6` successfully.