### PR TITLE
Remove dead code and fix unreachable MSM lock-time branch

### DIFF
--- a/python/bdsb2read.py
+++ b/python/bdsb2read.py
@@ -19,7 +19,6 @@
 # [3] Tomoji Takasu, Pocket SDR -An Open-Source GNSS SDR, ver. 0.11,
 #     https://github.com/tomojitakasu/PocketSDR
 
-POCKET_SDR_LDPC = 0            # change this to 1 if you use 64-ary LDPC function of Pocket SDR (ref.[3])
 LEN_BCNAV3      = 125          # BDS CNAV3 page size is 1000 sym (125 byte)
 PREAMBLE_BCNAV3 = b'\xeb\x90'  # preamble for BDS B2b message
 

--- a/python/gale6read.py
+++ b/python/gale6read.py
@@ -429,9 +429,7 @@ def icd_test():
     '''self test described in [1] attached file,
     Galileo-HAS-SIS-ICD_1.0_Annex_D_HAS_Message_Decoding_Example.txt
     To execute this ICD test,
-    python
-    >>> import gale6read
-    >>> gale6read.icd_test()
+    gale6read.py --icd-test
     '''
     trace    = libtrace.Trace(t_level=1)
     gale6    = GalE6(trace)
@@ -496,7 +494,13 @@ if __name__ == '__main__':
     parser.add_argument(
         '-t', '--trace', type=int, default=0,
         help='show display verbosely: 1=detail, 2=bit image.')
+    parser.add_argument(
+        '--icd-test', action='store_true',
+        help='execute the self test described in the Galileo HAS ICD and exit.')
     args = parser.parse_args()
+    if args.icd_test:
+        icd_test()
+        sys.exit(0)
     fp_disp = sys.stdout
     if args.trace < 0:
         libtrace.err(f'trace level should be positive ({args.trace}).')

--- a/python/libnav.py
+++ b/python/libnav.py
@@ -99,48 +99,6 @@ class NavGps:
             msg += self.trace.msg(0, f' unhealthy({e.svh.u:02x})', fg='red')
         return msg
 
-    def convert(self, svid: int) -> NavNull:
-        ''' decode GPS ephemeris '''
-        e       = self.eph[svid-1]
-        d       = NavNull()
-        d.m0    = e.m0.i   * 2**(-31)*PI  # mean anomaly at reference time
-        d.e     = e.e.u    * 2**(-33)     # eccentricity
-        d.a12   = e.a12.u  * 2**(-19)     # square root of the semi-major axis
-        d.t0e   = e.t0e.u  * 60           # ephemeris reference time
-        d.omg0  = e.omg0.i * 2**(-31)*PI  # longitude of ascending node of orbital plane
-        d.i0    = e.i0.i   * 2**(-31)*PI  # inclination angle at reference time
-        d.omg   = e.omg.i  * 2**(-31)*PI  # argument of perigee
-        d.idot  = e.idot.i * 2**(-43)*PI  # rate of change of inclination angle
-        d.dn    = e.dn.i   * 2**(-43)*PI  # mean motion difference from computed value
-        d.omgd  = e.omgd.i * 2**(-43)*PI  # rate of change of right ascension
-        d.cuc   = e.cuc.i  * 2**(-29)     # cos harmonic correction term to the argument of latitude
-        d.cus   = e.cus.i  * 2**(-29)     # sin harmonic correction term to the argument of latitude
-        d.crc   = e.crc.i  * 2**(-5)      # cos harmonic correction term to the orbit radius
-        d.crs   = e.crs.i  * 2**(-5)      # sin harmonic correction term to the orbit radius
-        d.cic   = e.cic.i  * 2**(-29)     # cos harmonic correction term to the angle of inclination
-        d.cis   = e.cis.i  * 2**(-29)     # sin harmonic correction term to the angle of inclination
-        d.t0c   = e.t0c.u  * 60           # clock correction data reference TOW
-        d.af0   = e.af0.i  * 2**(-34)     # SV clock bias correction coefficient
-        d.af1   = e.af1.i  * 2**(-46)     # SV clock drift correction coefficient
-        d.af2   = e.af2.i  * 2**(-59)     # SV clock drift rate correction coefficient
-        d.be5a  = e.be5a.i * 2**(-32)     # E1-E5a broadcast group delay
-        d.be5b  = e.be5b.i * 2**(-32)     # E1-E5b broadcast group delay
-        d.ai0   = e.ai0.u  * 2**(-2)      # effective ionisation level 1st order parameter
-        d.ai1   = e.ai1.i  * 2**(-8)      # effective ionisation level 2nd order parameter
-        d.a0    = e.a0.i   * 2**(-30)     # constant term of polynomial
-        d.a1    = e.a1.i   * 2**(-50)     # 1st order term of polynomial
-        d.dtls  = e.dtls.i                # leap Second count before leap second adjustment
-        d.t0t   = e.t0t.u                 # UTC data reference TOW
-        d.wn0t  = e.wn0t.u                # UTC data reference week number
-        d.wnlsf = e.wnlsf.u               # week number of leap second adjustment
-        d.dn    = e.dn.u                  # day number at the end of which a leap second adjustment becomes effective
-        d.dtlsf = e.dtlsf.i               # leap second count after leap second adjustment
-        d.a0g   = e.a0g.i  * 2**(-35)     # constant term of the polynomial describing the offset
-        d.a1g   = e.a1g.i  * 2**(-51)     # rate of change of the offset
-        d.t0g   = e.t0g.u  * 3600         # reference time for GGTO data
-        d.wn0g  = e.wn0g.u                # week number of GGTO reference
-        return d
-
 class NavGlo:
     ''' GLONASS ephemeris data '''
 

--- a/python/qzsl1sread.py
+++ b/python/qzsl1sread.py
@@ -70,8 +70,9 @@ class QzsL1s:
     mask_uh  : list[str] = []     # mask info for unhealthy satellite defined by MT51 (satellite health)
     iod      : list[int] = [0 for _ in range(23)]  # data issue number
 
-    def __init__(self, trace: libtrace.Trace) -> None:
+    def __init__(self, trace: libtrace.Trace, jp: bool = False) -> None:
         self.trace = trace
+        self.jp    = jp  # display DCR messages in Japanese
 
     def decode_test_mode(self, df: BitStream) -> str:  # ref.[3], sect.4.1.2.3, MT0
         ''' test mode messages solicit deleting previous messages stored in the receiver '''
@@ -273,10 +274,13 @@ class QzsL1s:
         vn   = df.read(  6).u  # version  # type: ignore
         if vn != 1:
             raise Exception(f"\nversion number should be 1 ({vn})")
-        msg = f": {self.DC2NAME_EN.get(dc, 'undefined classification')}" + \
-              f" ({self.RC2NAME_EN.get(rc, 'undefined priority')})"
+        dc2name = self.DC2NAME_JP if self.jp else self.DC2NAME_EN
+        rc2name = self.RC2NAME_JP if self.jp else self.RC2NAME_EN
+        it2name = self.IT2NAME_JP if self.jp else self.IT2NAME_EN
+        msg = f": {dc2name.get(dc, 'undefined classification')}" + \
+              f" ({rc2name.get(rc, 'undefined priority')})"
         if it != 0:
-            msg += f" {self.IT2NAME_EN.get(it, 'undefined information type')}"
+            msg += f" {it2name.get(it, 'undefined information type')}"
         msg += f" {atmo:02d}-{atda:02d} {atho:02d}:{atmi:02d} UTC"
         return msg
 
@@ -387,12 +391,15 @@ if __name__ == '__main__':
         '-t', '--trace', type=int, default=0,
         help='show display verbosely: 1=subtype detail, 2=subtype and bit image.')
     parser.add_argument(
+        '--jp', action='store_true',
+        help='show DCR (disaster and crisis management report) in Japanese.')
+    parser.add_argument(
         'l1s_files', metavar='file', nargs='*', default=None,
         help='L1S file(s) obtained from the QZS archive, https://sys.qzss.go.jp/dod/archives/slas.html')
     args = parser.parse_args()
     fp_disp = sys.stdout
     trace = libtrace.Trace(fp_disp, args.trace, args.color)
-    qzsl1s = QzsL1s(trace)
+    qzsl1s = QzsL1s(trace, args.jp)
     try:
         if args.l1s_files:  # read from file(s)
             for l1s_file in args.l1s_files:

--- a/python/rtcmread.py
+++ b/python/rtcmread.py
@@ -420,7 +420,7 @@ class Rtcm:
             psr = (df397[sat] + df398[sat] * 2**(-10) + df405 * rfpsr) * 1e-3 * libnav.C
             phr = df406 * rfphr * 1e-3 * libnav.C
             phr_rate = (df399[sat] + df404 * 1e-4) * 1e-3 * libnav.C
-            if 'MSM6' in mtype or 'MSM7':
+            if 'MSM6' in mtype or 'MSM7' in mtype:
                 t_lti = t_lti2(lti) * 1e-3  # high resolution lock time indication in second
             else:
                 t_lti = t_lti1(lti) * 1e-3  # low resolution lock time indication in second


### PR DESCRIPTION
## Summary

Dead-code removal, verified with `test/do_test.sh` (all 37 tests pass, no diff against `test/expect`).

### Changes

- **gale6read.py**: add `--icd-test` option to run the formerly unreferenced `icd_test()` (Galileo HAS ICD Annex D self test)
- **libnav.py**: remove unused `NavGps.convert()`
- **bdsb2read.py**: remove unused constant `POCKET_SDR_LDPC`
- **qzsl1sread.py**: add `--jp` option to use the formerly unused Japanese dictionaries (`RC2NAME_JP`, `DC2NAME_JP`, `IT2NAME_JP`) for DCR display
- **rtcmread.py**: fix always-true condition `'MSM6' in mtype or 'MSM7'` so the low-resolution lock time table (Table 3.5-74) is reachable for MSM4/MSM5

### Notes

- The rtcmread.py fix produces no diff against `test/expect` because all 604 MSM messages in the sample data are MSM7; behavior changes only for MSM4/MSM5 input.
- `b2b_parity` in bdsb2read.py and `decode_glol1of()`/`decode_bdsb1i()`/`decode_bdsb1i()` in ubxread.py are intentionally kept for future use.

DCR display check:
```
EN: PRN186: DCR: Marine (Normal) 09-19 08:40 UTC
JP: PRN186: DCR: 海上 (通常) 09-19 08:40 UTC
```