### PR TITLE
[codex] Fix PyPI README links

### DIFF
--- a/readme-en.md
+++ b/readme-en.md
@@ -1,8 +1,8 @@
 # QZS L6 Tool: quasi-zenith satellite L6-band tool, ver.0.1.7
 
-![QZS L6 Tool](docs/img/qzsl6tool.png)
+![QZS L6 Tool](https://raw.githubusercontent.com/yoronneko/qzsl6tool/main/docs/img/qzsl6tool.png)
 
-[日本語](readme.md)
+[日本語](https://github.com/yoronneko/qzsl6tool/blob/main/readme.md)
 
 ## Summary
 
@@ -11,7 +11,7 @@
 - It is designed to be used in conjunction with tools such as ``nc`` of netcat, and ``str2str`` of [RTKLIB](https://github.com/tomojitakasu/RTKLIB).
 - Initially, it aimed to display the content of augmentation messages broadcasted by the quasi-zenith satellite Michibiki (QZS) in the L6 frequency band, including CLAS and MADO. However, it is now also capable of displaying Galileo HAS messages.
 - [Semantic versioning](https://packaging.python.org/en/latest/discussions/versioning/#choosing-a-versioning-scheme) has been applied since 2024-08-11.
-- [Release note](release_note.md)
+- [Release note](https://github.com/yoronneko/qzsl6tool/blob/main/release_note.md)
 
 ## Operating Environment
 
@@ -52,32 +52,32 @@ Those who use Windows Git CLI, please execute ``git config --global core.autocrl
 
 | display | code |
 |:----:|:-------:|
-| RTCM |[rtcmread.py](docs/en/rtcmread.md) |
-| QZSS L6 |[qzsl6read.py](docs/en/qzsl6read.md) |
-| QZSS L1S | [qzsl1sread.py](docs/en/qzsl1sread.md) |
-| Galileo I/NAV | [galinavread.py](docs/en/galinavread.md) |
-| Galileo HAS |[gale6read.py](docs/en/gale6read.md) |
-|BeiDou PPP-B2b | [bdsb2read.py](docs/en/bdsb2read.md)|
+| RTCM |[rtcmread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/rtcmread.md) |
+| QZSS L6 |[qzsl6read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/qzsl6read.md) |
+| QZSS L1S | [qzsl1sread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/qzsl1sread.md) |
+| Galileo I/NAV | [galinavread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/galinavread.md) |
+| Galileo HAS |[gale6read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/gale6read.md) |
+|BeiDou PPP-B2b | [bdsb2read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/bdsb2read.md)|
 
 ## GNSS Receiver Data Conversion
 
 | GNSS receiver | code | QZS L6 | QZS L1S | Galileo HAS | Galileo I/NAV | BeiDou B2b |
 |:----:|:---:| :-------:|:-----------:|:--------:|:---:|:---:|
-| Allystar HD9310 option C | [alstread.py](docs/en/alstread.md) |``-l`` option | | | | |
-| [Pocket SDR](https://github.com/tomojitakasu/PocketSDR) | [psdrread.py](docs/en/psdrread.md) | ``-l`` option | ``-l1s`` option | ``-e`` option | ``-i`` option| ``-b`` option|
-| NovAtel OEM729 | [novread.py](docs/en/novread.md) | | | ``-e`` option | | |
-| Septentrio mosaic-X5 | [septread.py](docs/en/septread.md) | | | ``-e`` option | | ``-b`` option|
-| Septentrio mosaic-CLAS | [septread.py](docs/en/septread.md) |``-l`` option | | | | |
-| u-blox ZED-F9P | [ubxread.py](docs/en/ubxread.md) | | ``-l1s`` option | | ``-i`` option| |
+| Allystar HD9310 option C | [alstread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/alstread.md) |``-l`` option | | | | |
+| [Pocket SDR](https://github.com/tomojitakasu/PocketSDR) | [psdrread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/psdrread.md) | ``-l`` option | ``-l1s`` option | ``-e`` option | ``-i`` option| ``-b`` option|
+| NovAtel OEM729 | [novread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/novread.md) | | | ``-e`` option | | |
+| Septentrio mosaic-X5 | [septread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/septread.md) | | | ``-e`` option | | ``-b`` option|
+| Septentrio mosaic-CLAS | [septread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/septread.md) |``-l`` option | | | | |
+| u-blox ZED-F9P | [ubxread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/ubxread.md) | | ``-l1s`` option | | ``-i`` option| |
 
 ## Time & Coordinate Conversion
 
 | conversion | code |
 |:--:|:--:|
-|GPS time, GST, BST &rarr; UTC time | [gps2utc.py](docs/en/gps2utc.md) |
-|UTC time &rarr; GPS time, GST, BST | [utc2gps.py](docs/en/utc2gps.md)|
-|LLH &rarr;  ECEF | [llh2ecef.py](docs/en/llh2ecef.md)|
-|ECEF &rarr;  LLH | [ecef2llh.py](docs/en/ecef2llh.md)|
+|GPS time, GST, BST &rarr; UTC time | [gps2utc.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/gps2utc.md) |
+|UTC time &rarr; GPS time, GST, BST | [utc2gps.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/utc2gps.md)|
+|LLH &rarr;  ECEF | [llh2ecef.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/llh2ecef.md)|
+|ECEF &rarr;  LLH | [ecef2llh.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/ecef2llh.md)|
 
 ## Directory Structure
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # QZS L6 Tool: quasi-zenith satellite L6-band tool, ver.0.1.7
 
-![QZS L6 Tool](docs/img/qzsl6tool.png)
+![QZS L6 Tool](https://raw.githubusercontent.com/yoronneko/qzsl6tool/main/docs/img/qzsl6tool.png)
 
-[English](readme-en.md)
+[English](https://github.com/yoronneko/qzsl6tool/blob/main/readme-en.md)
 
 ## 概要
 
@@ -11,7 +11,7 @@
 - netcatの``nc``や、[RTKLIB](https://github.com/tomojitakasu/RTKLIB)の``str2str``などと一緒に利用することを想定しています。
 - 当初、準天頂衛星みちびき（QZS: quasi-zenith satellite）がL6周波数帯にて放送する補強メッセージ（CLASやMADOCA-PPP）の内容表示を目指していましたが、Galileo HASメッセージなども表示できるようになりました。
 - 2024年8月11日バージョンから[セマンテック・バージョニング](https://packaging.python.org/en/latest/discussions/versioning/#choosing-a-versioning-scheme)を導入しました。
-- [リリースノート](release_note.md)
+- [リリースノート](https://github.com/yoronneko/qzsl6tool/blob/main/release_note.md)
 
 ## 動作環境
 
@@ -52,32 +52,32 @@ Windows上でGNSSバイナリデータを扱う場合は、``cmd.exe``やPowerSh
 
 | display | code |
 |:----:|:-------:|
-| RTCM |[rtcmread.py](docs/ja/rtcmread.md) |
-| QZSS L6 |[qzsl6read.py](docs/ja/qzsl6read.md) |
-| QZSS L1S | [qzsl1sread.py](docs/ja/qzsl1sread.md) |
-| Galileo I/NAV | [galinavread.py](docs/ja/galinavread.md) |
-| Galileo HAS |[gale6read.py](docs/ja/gale6read.md) |
-|BeiDou PPP-B2b | [bdsb2read.py](docs/ja/bdsb2read.md)|
+| RTCM |[rtcmread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/rtcmread.md) |
+| QZSS L6 |[qzsl6read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/qzsl6read.md) |
+| QZSS L1S | [qzsl1sread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/qzsl1sread.md) |
+| Galileo I/NAV | [galinavread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/galinavread.md) |
+| Galileo HAS |[gale6read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/gale6read.md) |
+|BeiDou PPP-B2b | [bdsb2read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/bdsb2read.md)|
 
 ## GNSS受信機データ変換
 
 | GNSS receiver | code | QZS L6 | QZS L1S | Galileo HAS | Galileo I/NAV | BeiDou B2b |
 |:----:|:---:| :-------:|:-----------:|:--------:|:---:|:---:|
-| Allystar HD9310 option C | [alstread.py](docs/ja/alstread.md) |``-l`` option | | | | |
-| [Pocket SDR](https://github.com/tomojitakasu/PocketSDR) | [psdrread.py](docs/ja/psdrread.md) | ``-l`` option |  | ``-e`` option | ``-i`` option| ``-b`` option|
-| NovAtel OEM729 | [novread.py](docs/ja/novread.md) | | | ``-e`` option | | |
-| Septentrio mosaic-X5 | [septread.py](docs/ja/septread.md) | | | ``-e`` option | | ``-b`` option|
-| Septentrio mosaic-CLAS | [septread.py](docs/ja/septread.md) |``-l`` option | | | | |
-| u-blox ZED-F9P | [ubxread.py](docs/ja/ubxread.md) | | ``-l1s`` option | | ``-i`` option| |
+| Allystar HD9310 option C | [alstread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/alstread.md) |``-l`` option | | | | |
+| [Pocket SDR](https://github.com/tomojitakasu/PocketSDR) | [psdrread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/psdrread.md) | ``-l`` option |  | ``-e`` option | ``-i`` option| ``-b`` option|
+| NovAtel OEM729 | [novread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/novread.md) | | | ``-e`` option | | |
+| Septentrio mosaic-X5 | [septread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/septread.md) | | | ``-e`` option | | ``-b`` option|
+| Septentrio mosaic-CLAS | [septread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/septread.md) |``-l`` option | | | | |
+| u-blox ZED-F9P | [ubxread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/ubxread.md) | | ``-l1s`` option | | ``-i`` option| |
 
 ## 時刻・座標変換
 
 | conversion | code |
 |:--:|:--:|
-|GPS time, GST, BST &rarr; UTC time | [gps2utc.py](docs/ja/gps2utc.md) |
-|UTC time &rarr; GPS time, GST, BST | [utc2gps.py](docs/ja/utc2gps.md)|
-|LLH &rarr; ECEF | [llh2ecef.py](docs/ja/llh2ecef.md)|
-|ECEF &rarr; LLH | [ecef2llh.py](docs/ja/ecef2llh.md)|
+|GPS time, GST, BST &rarr; UTC time | [gps2utc.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/gps2utc.md) |
+|UTC time &rarr; GPS time, GST, BST | [utc2gps.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/utc2gps.md)|
+|LLH &rarr; ECEF | [llh2ecef.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/llh2ecef.md)|
+|ECEF &rarr; LLH | [ecef2llh.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/ecef2llh.md)|
 
 ## ディレクトリ構造
 


### PR DESCRIPTION
## Summary

- Replace README-relative documentation links with GitHub `blob/main/...` URLs so they work from the PyPI project description.
- Replace the local image path with a `raw.githubusercontent.com` image URL for PyPI rendering.
- Apply the same link updates to both Japanese and English README files.

## Why

PyPI renders `readme-en.md` as the project description, but relative links such as `readme.md`, `release_note.md`, and `docs/en/rtcmread.md` do not resolve to files in the GitHub repository from the PyPI page. Using absolute GitHub URLs avoids broken links while keeping the repository README usable.

## Validation

- Ran `rg` to confirm no README links remain pointing to relative `readme...`, `release_note...`, or `docs/...` paths.
- Ran `git diff --check` on the README changes.