### PR TITLE
Document l6rtcm4050.py and undocumented CLI options

### DIFF
--- a/docs/en/gale6read.md
+++ b/docs/en/gale6read.md
@@ -8,7 +8,7 @@ The ``--help`` option displays the options it accepts.
 
 ```bash
 $ gale6read.py --help
-usage: gale6read.py [-h] [-c] [-m] [-s] [-t TRACE]
+usage: gale6read.py [-h] [-c] [-m] [-s] [-t TRACE] [--icd-test]
 
 Galileo E6B message read, QZS L6 Tool ver.x.x.x
 
@@ -18,6 +18,7 @@ options:
   -m, --message         show display messages to stderr
   -s, --statistics      show HAS statistics in display messages.
   -t TRACE, --trace TRACE show display verbosely: 1=detail, 2=bit image.
+  --icd-test            execute the self test described in the Galileo HAS ICD and exit.
 ```
 
 When the ``-c`` option is given, it forces the status display to appear in color. By default, if the output destination is a terminal, the status display appears in color. If the output destination is something else, color display is not used.
@@ -27,6 +28,8 @@ When the ``-m`` option is given, it outputs the status display to standard error
 When the ``-s`` option is given, it also outputs the statistics information.
 
 When the ``-t`` option is given, it output detail on the messages. This option needs integer argument. The value 1 produces the detailed information, and the value 2 provides bit image display in addition of the detailed information.
+
+When the ``--icd-test`` option is given, it runs a self test using the sample data attached to the Galileo HAS ICD (Interface Control Document) instead of reading standard input, and then exits.
 
 For example, we extract HAS raw data from Pocket SDR logfile ``20230305-063900has.psdr`` with [psdrread.py](psdrread.md), and display it with ``gale6read.py``:
 

--- a/docs/en/qzsl1sread.md
+++ b/docs/en/qzsl1sread.md
@@ -4,7 +4,7 @@ This program reads QZSS L1S format data from standard input or a file and output
 
 ```bash
 $ qzsl1sread.py --help
-usage: qzsl1sread.py [-h] [-c] [-t TRACE] [file ...]
+usage: qzsl1sread.py [-h] [-c] [-t TRACE] [--jp] [file ...]
 
 Quasi-zenith satellite (QZS) L1S message read, QZS L6 Tool ver.x.x.x
 
@@ -15,6 +15,7 @@ options:
   -h, --help            show this help message and exit
   -c, --color           apply ANSI color escape sequences even for non-terminal.
   -t TRACE, --trace TRACE show display verbosely: 1=subtype detail, 2=subtype and bit image.
+  --jp                  show DCR (disaster and crisis management report) in Japanese.
 ```
 
 If no filename is provided, it reads from standard input. The input format is the same as the [SLAS Archive](https://sys.qzss.go.jp/dod/en/archives/slas.html) on the QZSS official page. Initially, 1 byte (8 bits) of PRN (pseudo random noise) number is followed by 32 bytes (250 bits, the rest is zero-padding) of data.
@@ -24,6 +25,8 @@ Terminal output is displayed in color using ANSI escape sequences. Redirecting t
 When the ``-c`` option is given, it forces the status display to appear in color. By default, if the output destination is a terminal, the status display appears in color. If the output destination is something else, color display is not used.
 
 When the ``-t`` option is given, it output detail on the messages. This option needs integer argument. The value 1 produces the detailed information, and the value 2 provides bit image display in addition of the detailed information.
+
+When the ``--jp`` option is given, it shows the DCR (disaster and crisis management report) content in Japanese. By default, it is shown in English.
 
 For example, we extract QZS L1S raw data from Allystar receiver raw data sample ``20230919-114418.ubx`` with [ubxread.py](ubxread.md), and display it with ``qzsl1sread.py``:
 

--- a/docs/ja/gale6read.md
+++ b/docs/ja/gale6read.md
@@ -8,7 +8,7 @@
 
 ```bash
 $ gale6read.py --help
-usage: gale6read.py [-h] [-c] [-m] [-s] [-t TRACE]
+usage: gale6read.py [-h] [-c] [-m] [-s] [-t TRACE] [--icd-test]
 
 Galileo E6B message read, QZS L6 Tool ver.x.x.x
 
@@ -18,6 +18,7 @@ options:
   -m, --message         show display messages to stderr
   -s, --statistics      show HAS statistics in display messages.
   -t TRACE, --trace TRACE show display verbosely: 1=detail, 2=bit image.
+  --icd-test            execute the self test described in the Galileo HAS ICD and exit.
 ```
 
 ``-c``オプションを与えると、強制的にカラーにて状態表示します。デフォルトでは、出力先がターミナルであれば、状態表示はカラーにて表示されます。出力先がそれ以外であれば、カラー表示されません。
@@ -27,6 +28,8 @@ options:
 ``-s``オプションを与えると、メッセージの統計情報も出力されます。
 
 ``-t``オプションを与えると、メッセージ内容の詳細が表示されます。このオプションは整数値とともに用います。数値1では詳細を、数値2ではそれに加えて、ビットイメージを表示します。
+
+``--icd-test``オプションを与えると、標準入力を使わず、Galileo HAS ICD（Interface Control Document）付属のセルフテスト用データを用いた自己診断を実行して終了します。
 
 例えば、サンプルディレクトリにあるPocket SDRログファイル``20230305-063900has.psdr``を[psdrread.py](psdrread.md)にてHAS生データを抽出し、``gale6read.py``にて内容表示します。
 

--- a/docs/ja/qzsl1sread.md
+++ b/docs/ja/qzsl1sread.md
@@ -6,7 +6,7 @@
 
 ```bash
 $ qzsl1sread.py --help
-usage: qzsl1sread.py [-h] [-c] [-t TRACE] [file ...]
+usage: qzsl1sread.py [-h] [-c] [-t TRACE] [--jp] [file ...]
 
 Quasi-zenith satellite (QZS) L1S message read, QZS L6 Tool ver.x.x.x
 
@@ -17,6 +17,7 @@ options:
   -h, --help            show this help message and exit
   -c, --color           apply ANSI color escape sequences even for non-terminal.
   -t TRACE, --trace TRACE show display verbosely: 1=subtype detail, 2=subtype and bit image.
+  --jp                  show DCR (disaster and crisis management report) in Japanese.
 ```
 
 ファイル名が与えられなければ、標準入力から読み取ります。入力形式は、みちびき公式ページの[SLASアーカイブ](https://sys.qzss.go.jp/dod/en/archives/slas.html)と同様です。最初に、1バイト（8ビット）のPRN（pseudo random noise）番号の後、32バイト（250ビット、残りはゼロパディング）のデータが続きます。
@@ -26,6 +27,8 @@ options:
 ``-c``オプションを与えると、強制的にカラーにて状態表示します。デフォルトでは、出力先がターミナルであれば、状態表示はカラーにて表示されます。出力先がそれ以外であれば、カラー表示されません。
 
 ``-t``オプションを与えると、メッセージ内容の詳細が表示されます。このオプションは整数値とともに用います。数値1では詳細を、数値2ではそれに加えて、ビットイメージを表示します。
+
+``--jp``オプションを与えると、災害・危機管理通報（DCR: disaster and crisis management report）を日本語で表示します。デフォルトでは英語表示です。
 
 例えば、サンプルディレクトリにあるu-blox ZED-F9P受信機生データファイル``20230919-114418.ubx``を[ubxread.py](ubxread.md)にてL1S生データを抽出し、``qzsl1sread.py``にて内容表示します。
 

--- a/readme-en.md
+++ b/readme-en.md
@@ -59,12 +59,18 @@ Those who use Windows Git CLI, please execute ``git config --global core.autocrl
 | Galileo HAS |[gale6read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/gale6read.md) |
 |BeiDou PPP-B2b | [bdsb2read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/bdsb2read.md)|
 
+## RTCM Format Conversion
+
+| conversion | code |
+|:----:|:-------:|
+| QZS L6 &rarr; RTCM message type 4050 | [l6rtcm4050.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/l6rtcm4050.md) |
+
 ## GNSS Receiver Data Conversion
 
 | GNSS receiver | code | QZS L6 | QZS L1S | Galileo HAS | Galileo I/NAV | BeiDou B2b |
 |:----:|:---:| :-------:|:-----------:|:--------:|:---:|:---:|
 | Allystar HD9310 option C | [alstread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/alstread.md) |``-l`` option | | | | |
-| [Pocket SDR](https://github.com/tomojitakasu/PocketSDR) | [psdrread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/psdrread.md) | ``-l`` option | ``-l1s`` option | ``-e`` option | ``-i`` option| ``-b`` option|
+| [Pocket SDR](https://github.com/tomojitakasu/PocketSDR) | [psdrread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/psdrread.md) | ``-l`` option |  | ``-e`` option | ``-i`` option| ``-b`` option|
 | NovAtel OEM729 | [novread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/novread.md) | | | ``-e`` option | | |
 | Septentrio mosaic-X5 | [septread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/septread.md) | | | ``-e`` option | | ``-b`` option|
 | Septentrio mosaic-CLAS | [septread.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/en/septread.md) |``-l`` option | | | | |

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,12 @@ Windows上でGNSSバイナリデータを扱う場合は、``cmd.exe``やPowerSh
 | Galileo HAS |[gale6read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/gale6read.md) |
 |BeiDou PPP-B2b | [bdsb2read.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/bdsb2read.md)|
 
+## RTCM形式変換
+
+| conversion | code |
+|:----:|:-------:|
+| QZS L6 &rarr; RTCM message type 4050 | [l6rtcm4050.py](https://github.com/yoronneko/qzsl6tool/blob/main/docs/ja/l6rtcm4050.md) |
+
 ## GNSS受信機データ変換
 
 | GNSS receiver | code | QZS L6 | QZS L1S | Galileo HAS | Galileo I/NAV | BeiDou B2b |


### PR DESCRIPTION
## Summary
- Add `l6rtcm4050.py` (QZS L6 → RTCM 4050 conversion) to readme.md / readme-en.md — it already had doc pages under docs/ja and docs/en but was never linked from the top-level readmes.
- Document `gale6read.py`'s `--icd-test` option and `qzsl1sread.py`'s `--jp` option, both present in code but missing from their doc pages.
- Fix a stale `-l1s` option reference for `psdrread.py` in readme-en.md's receiver table (psdrread.py has no such option; the ja readme was already correct).

## Test plan
- [x] Documentation-only change; no code was modified.
- [x] Verified every `python/*.py` CLI tool's `argparse` options against its `docs/ja/*.md` and `docs/en/*.md` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)