### PR TITLE
Fix GNSS decoder conditions and UBX output modes

### DIFF
--- a/python/libssr.py
+++ b/python/libssr.py
@@ -591,7 +591,7 @@ class Ssr:
                     if len_payload < payload.pos + 13:
                         return False
                     c0 = payload.read(13)
-                    if c0.b != '1000000000000' and c0.b == '0111111111111':
+                    if c0.b != '1000000000000' and c0.b != '0111111111111':
                         msg1 += f"\nCKSUB {gsys} {c0.i*2.5e-3*multiplier:{FMT_CLK}}"
         self.trace.show(1, msg1)
         self.stat_both += stat_pos

--- a/python/qzsl6read.py
+++ b/python/qzsl6read.py
@@ -117,7 +117,7 @@ class QzsL6:
                 self.patid    = 0          # reserved pattern ID
                 # self.facility = "Unknown"  # then, the facility is not defined
             else:
-                self.patid  = (self.mtid >> 2) & 1 + 1  # ref.[7], CLAS pattern ID: 1 or 2, ref.[1] Table 4.1.2-2
+                self.patid  = ((self.mtid >> 2) & 1) + 1  # ref.[7], CLAS pattern ID: 1 or 2, ref.[1] Table 4.1.2-2
                 if (self.mtid >> 3) & 0b11 == 0b00:  # CLAS facility ID depends on pattern ID, very complex...
                     if self.patid == 1:
                         self.facility = "Hitachi-Ota:0"  # Facility 1

--- a/python/ubxread.py
+++ b/python/ubxread.py
@@ -179,7 +179,7 @@ class UbxReceiver:
         ''' returns decoded raw
             format: [SVID(8)][L1OF/L2OF RAW(300)][padding(3)]...
         '''
-        if self.signame != 'L1OF' or self.signame != 'L2OF':
+        if self.signame not in ('L1OF', 'L2OF'):
             return None
         l1of = BitStream(uint=self.svid, length=8) + self.payload
         return l1of.tobytes()
@@ -188,7 +188,7 @@ class UbxReceiver:
         ''' returns decoded raw
             format: [SVID(8)][B1I/B2I RAW(300)][padding(4)]...
         '''
-        if self.signame != 'B1I' or self.signame != 'B2I':
+        if self.signame not in ('B1I', 'B2I'):
             return None
         b1i = BitStream(uint=self.svid, length=8) + self.payload
         return b1i.tobytes()
@@ -198,13 +198,15 @@ if __name__ == '__main__':
         description=f'u-blox message read, QZS L6 Tool ver.{libqzsl6tool.VERSION}')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--l1s', action='store_true',
-        help='send QZS L1S messages to stdout')
+        help='send SBAS and QZS L1S messages to stdout')
+    group.add_argument('--l1of', action='store_true',
+        help='send GLO L1OF messages to stdout')
     group.add_argument('--qzqsm', action='store_true',
         help='send QZS L1S DCR NMEA messages to stdout')
-    group.add_argument('--sbas', action='store_true',
-        help='send SBAS messages to stdout')
     group.add_argument('-l', '--lnav', action='store_true',
         help='send GPS or QZS LNAV messages to stdout')
+    group.add_argument('--b1i', action='store_true',
+        help='send BDS B1I messages to stdout')
     group.add_argument('-i', '--inav', action='store_true',
         help='send GAL I/NAV messages to stdout')
     parser.add_argument('-d', '--duplicate', action='store_true',
@@ -218,7 +220,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     fp_disp: TextIO | None = sys.stdout
     fp_raw : TextIO | None  = None
-    if args.l1s or args.qzqsm or args.sbas or args.lnav or args.inav:
+    if args.l1s or args.qzqsm or args.lnav or args.inav or args.l1of or args.b1i:
         fp_disp = None
         fp_raw = sys.stdout
         payload_prev = BitStream()
@@ -239,6 +241,8 @@ if __name__ == '__main__':
                 elif args.qzqsm: raw = rcv.decode_qzsl1s_qzqsm(args)
                 elif args.lnav : raw = rcv.decode_gpslnav()
                 elif args.inav : raw = rcv.decode_galinav()
+                elif args.l1of : raw = rcv.decode_glol1of()
+                elif args.b1i : raw = rcv.decode_bdsb1i()
                 if raw:
                     fp_raw.buffer.write(raw)
     except (BrokenPipeError, IOError):

--- a/python/ubxread.py
+++ b/python/ubxread.py
@@ -200,7 +200,7 @@ if __name__ == '__main__':
     group.add_argument('--l1s', action='store_true',
         help='send SBAS and QZS L1S messages to stdout')
     group.add_argument('--l1of', action='store_true',
-        help='send GLO L1OF messages to stdout')
+        help='send GLO L1OF/L2OF messages to stdout')
     group.add_argument('--qzqsm', action='store_true',
         help='send QZS L1S DCR NMEA messages to stdout')
     group.add_argument('-l', '--lnav', action='store_true',


### PR DESCRIPTION
GLONASS/BeiDouのUBXデコードが常にNoneを返す条件式、HAS時計補正の値の選別、CLASパターンIDの演算優先順位を修正します。

- UBXのL1OF/L2OF、B1I/B2Iを正しく通し、`--l1of`・`--b1i`からバイナリ出力できるようにします。出力オプションは相互排他です。
- HAS時計補正のsubset処理で、full処理と同じ2つの特殊値を除外します。
- CLASの非予約パターンIDを1/2として計算し、施設判定とパターン表示を可能にします。
- 未動作だった`--sbas`は削除し、SBASとQZSS L1Sの出力を既存の`--l1s`に統合します。利用側は`--l1s`への変更が必要です。

検証: 全6出力モードと引数なしでの空入力、出力オプション全15組の排他チェック、合成UBXフレーム7ケースのバイナリ出力一致を確認しました。HAS条件式は13ビット全8,192値、CLAS式は予約値を除く全CLASメッセージIDで確認済みです。`git diff --check`も通過しています。実受信データによる全機能の検証は行っていません。
