### PR TITLE
Disable CLAS pattern ID display until test data is updated

### DIFF
--- a/python/qzsl6read.py
+++ b/python/qzsl6read.py
@@ -242,9 +242,10 @@ class QzsL6:
             msg += f' SF{self.sfn} DP{self.dpn}'
             if self.vendor == "MADOCA-PPP":  # ref.[3], service ID and extension (Table 4.2.1-3)
                 msg += f' {self.servid} {self.msg_ext}:'
-            if self.vendor == "CLAS":        # ref.[7], pattern ID (Table 4.1.2-2)
-                if self.patid != 0:
-                    msg += f' P{self.patid}'
+            # To do: how to show the pattern ID for CLAS messages
+            # if self.vendor == "CLAS":        # ref.[7], pattern ID (Table 4.1.2-2)
+            #     if self.patid != 0:
+            #         msg += f' P{self.patid}'
         if self.read_cssr():  # found a CSSR message
             msg += f' ST{self.ssr.subtype}'
             while self.read_cssr():  # try to decode next message

--- a/python/qzsl6read.py
+++ b/python/qzsl6read.py
@@ -242,7 +242,7 @@ class QzsL6:
             msg += f' SF{self.sfn} DP{self.dpn}'
             if self.vendor == "MADOCA-PPP":  # ref.[3], service ID and extension (Table 4.2.1-3)
                 msg += f' {self.servid} {self.msg_ext}:'
-            # To do: how to show the pattern ID for CLAS messages
+            # Temporarily disable CLAS pattern ID display until test/expect data is updated (format TBD).
             # if self.vendor == "CLAS":        # ref.[7], pattern ID (Table 4.1.2-2)
             #     if self.patid != 0:
             #         msg += f' P{self.patid}'


### PR DESCRIPTION
## Summary
- CLAS messages のパターンID (ref.[7] Table 4.1.2-2) 表示を試みたところ、`test/do_test.sh` が既存の期待値と一致せず失敗するようになった
- パターンIDの表示方法（フォーマットや期待値データの更新方法）は今後検討するため、該当箇所を一旦コメントアウト

## Test plan
- [x] `cd test && ./do_test.sh` が全てPassすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)